### PR TITLE
ci: :green_heart: nix-installer-actionからdeterminate-nix-actionに移行

### DIFF
--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+        uses: DeterminateSystems/determinate-nix-action@f4c468f2287f0f14a113841b41f2dc8957119519 # v3.19.0
         with:
           extra-conf: |
             sandbox = false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+        uses: DeterminateSystems/determinate-nix-action@f4c468f2287f0f14a113841b41f2dc8957119519 # v3.19.0
         with:
           extra-conf: |
             sandbox = false

--- a/.github/workflows/treefmt.yaml
+++ b/.github/workflows/treefmt.yaml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+        uses: DeterminateSystems/determinate-nix-action@f4c468f2287f0f14a113841b41f2dc8957119519 # v3.19.0
         with:
           extra-conf: |
             sandbox = false


### PR DESCRIPTION
## Summary
- CI で利用している Nix セットアップ Action を `DeterminateSystems/nix-installer-action` から `DeterminateSystems/determinate-nix-action@v3.19.0` に置き換え

## Affected Files
- `.github/workflows/eslint.yaml`
- `.github/workflows/test.yaml`
- `.github/workflows/treefmt.yaml`

Closes #115

## Test plan
- [ ] ESLint workflow が成功する
- [ ] Test workflow が成功する
- [ ] treefmt workflow が成功する