### PR TITLE
ci: cffnpwr/actions参照の# main付与とcommitlint workflow追加

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,18 @@
+name: commitlint
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow_ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  commitlint:
+    uses: cffnpwr/actions/.github/workflows/commitlint.yaml@8c50ed3d1d5b4b7a113385add28e75cd229add0d # main
+    permissions:
+      contents: read
+      actions: read

--- a/.github/workflows/github-actions-lint.yaml
+++ b/.github/workflows/github-actions-lint.yaml
@@ -17,6 +17,6 @@ permissions: {}
 
 jobs:
   lint:
-    uses: cffnpwr/actions/.github/workflows/github-actions-lint.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/github-actions-lint.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
       contents: read

--- a/.github/workflows/semantic-pr-title.yaml
+++ b/.github/workflows/semantic-pr-title.yaml
@@ -17,6 +17,6 @@ permissions: {}
 
 jobs:
   semantic-pr-title:
-    uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/semantic-pr-title.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
       pull-requests: read

--- a/.github/workflows/status-check.yaml
+++ b/.github/workflows/status-check.yaml
@@ -17,8 +17,10 @@ permissions: {}
 
 jobs:
   status-check:
-    uses: cffnpwr/actions/.github/workflows/status-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb
+    uses: cffnpwr/actions/.github/workflows/status-check.yaml@827d6803313793c29f98826d5d9c00e92da976cb # main
     permissions:
+      contents: read
+      actions: read
       pull-requests: read
       checks: read
       statuses: read


### PR DESCRIPTION
## 概要

- 再利用ワークフロー参照 `cffnpwr/actions/.github/workflows/*.yaml@<sha>` に `# main` アンカーコメントを付与（`github-actions-lint.yaml` / `semantic-pr-title.yaml` / `status-check.yaml`）。SHAは既存のまま維持し、main HEADへのdigest bumpはrenovateに委ねる。
- `status-check.yaml` の呼び出しに `contents: read` と `actions: read` を追加。
- commitlint workflow (`commitlint.yaml`) を新規追加。`cffnpwr/actions/.github/workflows/commitlint.yaml@8c50ed3d... # main` を呼び出す。

## 背景・理由

- コメント無しの生SHA pinはrenovateが既定で追跡せず（どのブランチ/タグのSHAか判定できないため）、cffnpwr/actionsのmain更新に追従できていなかった。`# main` アンカーを付けることでrenovateが追跡し、digest更新PRを生成できるようになる。
- renovateがmain HEAD（現 `8c50ed3d`）へbumpすると、`status-check.yaml` の再利用ワークフローが `contents: read` と `actions: read` を要求する。digest更新PRのマージでStatus checkが `startup_failure` にならないよう、先行して両権限を付与する。
- コミット規約をCIで強制するため、共有 `@cffnpwr/commitlint-config` を用いる再利用ワークフローの呼び出しを追加する。ローカルにcommitlint設定が無いため、再利用ワークフロー既定の共有設定が使われる。commitlint.yamlは旧SHAに存在しないためmain HEADにpinする。

## 影響

- 破壊的変更なし。
- `status-check.yaml` は許可を追加するのみ（既存の `pull-requests` / `checks` / `statuses` は維持）。
- 新規 `commitlint.yaml` はPR時にコミットメッセージを検証する。規約違反のコミットを含むPRはこのチェックで失敗する。
- マージ後、renovateが `github-actions-lint` / `semantic-pr-title` / `status-check` の各参照をmain HEADへ更新するdigest PRを生成する見込み。

## 関連

Closes #136
Ref #135
